### PR TITLE
Fix for '(lookup-key map [return] t)' returning nil

### DIFF
--- a/org-notepad.el
+++ b/org-notepad.el
@@ -141,7 +141,7 @@ Like `org-tree-to-indirect-buffer', but does what we need."
 The function renames the buffer to the first heading's name when
 point is on a heading, then calls `org-notepad-goto-entry-end'."
   (let* ((map (copy-keymap (current-local-map)))
-         (orig-def (lookup-key map [return] t))
+         (orig-def (lookup-key map (kbd "RET") t))
          (docstring (format "With point on a heading, rename buffer accordingly, then call `org-notepad-goto-entry-end'.
 Otherwise, call %s."
                             orig-def))


### PR DESCRIPTION
  Previously orig-def was being set to nil.
  Changed [return] to (kbd "RET") to fix. 
  GNU Emacs 27.2 (build 1, x86_64-apple-darwin20.3.0, Carbon Version 164 AppKit 2022.3)